### PR TITLE
Better efficiency for logs table generation

### DIFF
--- a/src/WordPressHandler/WordPressHandler.php
+++ b/src/WordPressHandler/WordPressHandler.php
@@ -70,7 +70,7 @@ class WordPressHandler extends AbstractProcessingHandler
     /**
      * Initializes this handler by creating the table if it not exists
      */
-    private function initialize(array $record)
+    public function initialize(array $record)
     {
 
         // referenced

--- a/src/WordPressHandler/WordPressHandler.php
+++ b/src/WordPressHandler/WordPressHandler.php
@@ -17,7 +17,7 @@ class WordPressHandler extends AbstractProcessingHandler
     /**
      * @var bool defines whether the MySQL connection is been initialized
      */
-    private $initialized = false;
+    public $initialized = false;
     /**
      * @var WPDB wpdb object of database connection
      */


### PR DESCRIPTION
This package currently checks the DB and does a little extra work on first write every time a new instance of `WordPressHandler` is created. The process could be made a little more efficient by allowing wordpress developers to do the following with a plugin:

```php
require __DIR__.'/vendor/autoload.php';

// Create the logs table if it doesn't already exist on plugin activation
function register_activation_hook(__FILE__, function() {
    global $wpdb;

    $handler = new \WordPressHandler\WordPressHandler(
        $wpdb, "logs",
        [],
        \Monolog\Logger::DEBUG
    );

    $record = ['extra' => []];
    $handler->initialize($record);
});

// Now somewhere else in my plugin where I want to use the logger
$logger = new \Monolog\Logger('channel');
$handler = new \WordPressHandler\WordPressHandler(
    $wpdb, "logs",
    [],
    \Monolog\Logger::DEBUG
);
$handler->initialized = true; // Don't do any extra work - we've already done it.
$logger->pushHandler($handler);

$logger->warn('Some message');
```