### PR TITLE
Add table name setter

### DIFF
--- a/src/WordPressHandler/WordPressHandler.php
+++ b/src/WordPressHandler/WordPressHandler.php
@@ -35,6 +35,10 @@ class WordPressHandler extends AbstractProcessingHandler
      */
     private $prefix = 'wp_';
     /**
+     * @var string the full table name
+     */
+    private $fullTableName = 'wp_logs';
+    /**
      * @var string[] additional fields to be stored in the database
      *
      * For each field $field, an additional context field with the name $field
@@ -63,9 +67,17 @@ class WordPressHandler extends AbstractProcessingHandler
         }
         $this->table = $table;
         $this->prefix = $this->wpdb->prefix;
+        $this->fullTableName = $this->prefix . $this->table;
 
         $this->additionalFields = $additionalFields;
         parent::__construct($level, $bubble);
+    }
+    /**
+     * Sets the full log tables name
+     */
+    public function set_table_name($name)
+    {
+        $this->fullTableName = $name;
     }
     /**
      * Returns the full log tables name
@@ -74,7 +86,7 @@ class WordPressHandler extends AbstractProcessingHandler
      */
     public function get_table_name()
     {
-        return $this->prefix . $this->table;
+        return $this->fullTableName;
     }
     /**
      * Initializes this handler by creating the table if it not exists
@@ -157,19 +169,19 @@ class WordPressHandler extends AbstractProcessingHandler
 
         // json encode values as needed
         array_walk($recordExtra, function(&$value, $key) {
-        	if(is_array($value) || $value instanceof \Traversable) {
-        		$value = json_encode($value);
-        	}
+            if(is_array($value) || $value instanceof \Traversable) {
+                $value = json_encode($value);
+            }
         });
 
         $contentArray = $contentArray + $recordExtra;
 
         if(count($this->additionalFields) > 0) {
-	        //Fill content array with "null" values if not provided
-	        $contentArray = $contentArray + array_combine(
-	            $this->additionalFields,
-	            array_fill(0, count($this->additionalFields), null)
-	        );
+            //Fill content array with "null" values if not provided
+            $contentArray = $contentArray + array_combine(
+                $this->additionalFields,
+                array_fill(0, count($this->additionalFields), null)
+            );
         }
 
         $table_name = $this->get_table_name();

--- a/src/WordPressHandler/WordPressHandler.php
+++ b/src/WordPressHandler/WordPressHandler.php
@@ -67,7 +67,7 @@ class WordPressHandler extends AbstractProcessingHandler
         }
         $this->table = $table;
         $this->prefix = $this->wpdb->prefix;
-        $this->fullTableName = $this->prefix . $this->table;
+        $this->set_table_name($this->prefix.$this->table);
 
         $this->additionalFields = $additionalFields;
         parent::__construct($level, $bubble);
@@ -123,7 +123,9 @@ class WordPressHandler extends AbstractProcessingHandler
             channel VARCHAR(255),
             level INTEGER,
             message LONGTEXT,
-            time INTEGER UNSIGNED$extraFields$additionalFields,
+            time INTEGER UNSIGNED
+            $extraFields
+            $additionalFields,
             PRIMARY KEY  (id)
             ) $charset_collate;";
 


### PR DESCRIPTION
The current table name getter has issues when used with multisite wordpress as $wpdb->prefix changes with the blog. It could be `wp_`, `wp2_` etc.

Take the following example:
```php
// Create logs table on plugin activation
register_activation_hook(__FILE__, 'qpsl_activate');
function qpsl_activate() {
    require __DIR__."/vendor/autoload.php";
    global $wpdb;

    $handler = new \WordPressHandler\WordPressHandler(
        $wpdb, "qpsl_logs",
        [],
        \Monolog\Logger::DEBUG
    );
    $handler->initialize(['extra' => []]);
}
```

This will create a table *wp_qpsl_logs* when the plugin is network activated, however when I'm on blog 3 and attempt to log, I'll get an error because the current getter uses `$wpdb->prefix.$this->table` which is *wp3_qpsl_logs*.

I simply added a table name setter so you'd instead do something like:

```php
// Create logs table on plugin activation
register_activation_hook(__FILE__, 'qpsl_activate');
function qpsl_activate() {
    require __DIR__."/vendor/autoload.php";
    global $wpdb;

    $handler = new \WordPressHandler\WordPressHandler(
        $wpdb, "qpsl_logs",
        [],
        \Monolog\Logger::DEBUG
    );
    $handler->set_table_name($wpdb->base_prefix.'qpsl_logs');
    $handler->initialize(['extra' => []]);
}

// And where you want to use the logger
    $logger = new \Monolog\Logger($plugin_name);
    $handler = new \WordPressHandler\WordPressHandler(
        $wpdb, "qpsl_logs",
        [],
        \Monolog\Logger::DEBUG
    );
    // We already created the logs table on plugin installation. Don't do it again.
    $handler->initialized = true;
    $handler->set_table_name($wpdb->base_prefix.'qpsl_logs');

    $logger->pushHandler($handler);
```