### PR TITLE
Added ` quotes around additional and extra fields

### DIFF
--- a/src/WordPressHandler/WordPressHandler.php
+++ b/src/WordPressHandler/WordPressHandler.php
@@ -97,13 +97,13 @@ class WordPressHandler extends AbstractProcessingHandler
         // allow for Extra fields
         $extraFields = '';
         foreach ($record['extra'] as $key => $val) {
-            $extraFields.=",\n$key TEXT NULL DEFAULT NULL";
+            $extraFields.=",\n`$key` TEXT NULL DEFAULT NULL";
         }
 
         // additional fields
         $additionalFields = '';
         foreach ($this->additionalFields as $f) {
-            $additionalFields.=",\n$f TEXT NULL DEFAULT NULL";
+            $additionalFields.=",\n`$f` TEXT NULL DEFAULT NULL";
         }
 
         $sql = "CREATE TABLE $table_name (


### PR DESCRIPTION
This fixes issue when an extra/additional field is tried to be defined using a reserved SQL keyword as name. Example: "procedure" will cause "WordPress database error" written directly to the admin UI, and indeed failure to create logging table. Using the ` quotes around the field names fixes the issue.